### PR TITLE
windows支持

### DIFF
--- a/bin/housemd.bat
+++ b/bin/housemd.bat
@@ -1,0 +1,18 @@
+@echo off
+if 'x%JAVA_HOME%'=='x' (
+	echo.
+	echo Please set JAVA_HOME to JDK 6+!
+	echo.
+	goto end
+)
+
+:execute
+rem create logs dir if it doesn't exists
+if not exist logs (mkdir logs)
+
+set TOOL_JAR=%JAVA_HOME%\lib\tools.jar
+if exist %TOOL_JAR% (set BOOT_CLASSPATH=-Xbootclasspath/a:%TOOL_JAR%)
+%JAVA_HOME%\bin\java %BOOT_CLASSPATH% -jar %~dp0housemd.jar %*
+
+:end
+rem do nothing.

--- a/src/main/scala/com/github/zhongl/housemd/HouseMD.scala
+++ b/src/main/scala/com/github/zhongl/housemd/HouseMD.scala
@@ -42,10 +42,10 @@ object HouseMD extends Command("housemd", "a runtime diagnosis tool of JVM.", Pr
   private val pid  = parameter[String]("pid", "id of process to be diagnosing.")
 
 
-  private lazy val agentJarFile = sourceOf(getClass)
+  private lazy val agentJarFile = new File(sourceOf(getClass)).getCanonicalPath()
   private lazy val agentOptions = agentJarFile :: classNameOf[Telephone] :: port() :: classNameOf[Trace] :: classNameOf[Loaded] :: Nil
 
-  private lazy val errorDetailFile   = "/tmp/housemd.err." + pid()
+  private lazy val errorDetailFile   = "logs/housemd.err." + pid()
   private lazy val errorDetailWriter = new BufferedWriter(new FileWriter(errorDetailFile))
 
   def run() {


### PR DESCRIPTION
issue #37的处理,windows支持.
1.agentJarFile取值通过File.getCanonicalPath转换避免平台间的差异.
2.errorlog的路径由/tmp修改为logs.当执行的当前目录创建日志目录.
3.添加了bat执行脚本.

不过,目前还没有能够进入console.
java version "1.6.0_21"
Java(TM) SE Runtime Environment (build 1.6.0_21-b07)
Java HotSpot(TM) 64-Bit Server VM (build 17.0-b17, mixed mode)
以下是截取了一段jstack,看上去是两边通信的流读取没有结束. Telephone.scala 47跟源码有点没对上.
2012-06-16 15:54:25
Full thread dump Java HotSpot(TM) 64-Bit Server VM (17.0-b17 mixed mode):

"NonBlockingInputStreamThread" daemon prio=6 tid=0x000000002c4cc000 nid=0xb3c in Object.wait() [0x00000000373af000]
   java.lang.Thread.State: WAITING (on object monitor)
    at java.lang.Object.wait(Native Method)
    - waiting on <0x000000002255eb70> (a jline.internal.NonBlockingInputStream)
    at jline.internal.NonBlockingInputStream.run(NonBlockingInputStream.java:276)
    - locked <0x000000002255eb70> (a jline.internal.NonBlockingInputStream)
    at java.lang.Thread.run(Thread.java:619)

"HouseMD-Duck" daemon prio=6 tid=0x000000002c4cb000 nid=0x19b4 runnable [0x000000003718f000]
   java.lang.Thread.State: RUNNABLE
    at java.net.SocketInputStream.socketRead0(Native Method)
    at java.net.SocketInputStream.read(SocketInputStream.java:129)
    at java.net.SocketInputStream.read(SocketInputStream.java:182)
    at jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:167)
    - locked <0x000000002255eb70> (a jline.internal.NonBlockingInputStream)
    at jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:135)
    at jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:244)
    at jline.internal.InputStreamReader.read(InputStreamReader.java:268)
    - locked <0x000000002255eb70> (a jline.internal.NonBlockingInputStream)
    at jline.internal.InputStreamReader.read(InputStreamReader.java:205)
    - locked <0x000000002255eb70> (a jline.internal.NonBlockingInputStream)
    at jline.console.ConsoleReader.readCharacter(ConsoleReader.java:1911)
    at jline.console.ConsoleReader.readLine(ConsoleReader.java:2109)
    at jline.console.ConsoleReader.readLine(ConsoleReader.java:2033)
    at jline.console.ConsoleReader.readLine(ConsoleReader.java:2021)
    at com.github.zhongl.yascli.Shell.interact(Shell.scala:58)
    at com.github.zhongl.yascli.Shell.main(Shell.scala:33)
    at com.github.zhongl.housemd.Telephone.run(Telephone.scala:47)
    at java.lang.Thread.run(Thread.java:619)
