### PR TITLE
Introduced option to serialize parameters and result detail in json during trace

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -101,7 +101,8 @@ object Build extends sbt.Build {
       "asm" % "asm" % "3.3.1",
       "asm" % "asm-commons" % "3.3.1",
       "com.github.zhongl" %% "yascli" % "0.1.0",
-      "org.scala-lang" % "scala-library" % "2.9.2"
+      "org.scala-lang" % "scala-library" % "2.9.2",
+      "com.cedarsoftware" % "json-io" % "2.7.3"
     )
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,12 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
+//addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-RC1")
+//addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0-RC1")
+
+resolvers += Resolver.url("sbt-plugin-releases-scalasbt", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("org.scala-sbt" % "xsbt-proguard-plugin" % "0.1.3")
 
 resolvers += Resolver.url("sbt-plugin-releases",
   new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-proguard-plugin" % (v+"-0.1.1"))

--- a/src/main/scala/com/github/zhongl/housemd/command/Trace.scala
+++ b/src/main/scala/com/github/zhongl/housemd/command/Trace.scala
@@ -158,13 +158,16 @@ class DetailWriter(writer: BufferedWriter) {
     val thread = "[" + context.thread.getName + "]"
     val thisObject = if (context.thisObject == null) "null" else context.thisObject.toString
     val method = context.className + "." + context.methodName
-    val arguments = context.arguments.mkString("[", " ", "]")
+    val arguments = context.arguments.mkString("[" + ObjUtils.parameterSeparator, ObjUtils.parameterSeparator, "]")
     val resultOrExcption = context.resultOrException match {
       case Some(x)                      => ObjUtils.toString(x)
       case None if context.isVoidReturn => "void"
       case None                         => "null"
     }
-    val line = (started :: elapse :: thread :: thisObject :: method :: arguments :: resultOrExcption :: Nil)
+
+    val argumentsAndResult = "Arguments: " + arguments + ObjUtils.parameterSeparator + "Result: " + resultOrExcption
+
+    val line = (started :: elapse :: thread :: thisObject :: method :: argumentsAndResult :: Nil)
       .mkString(" ")
     writer.write(line)
     writer.newLine()

--- a/src/main/scala/com/github/zhongl/housemd/command/Trace.scala
+++ b/src/main/scala/com/github/zhongl/housemd/command/Trace.scala
@@ -184,40 +184,6 @@ class DetailWriter(writer: BufferedWriter) {
   }
 }
 
-class JsonDetailWriter(writer: BufferedWriter) extends DetailWriter(writer) {
-
-  override def write(context: Context) {
-    val started = "%1$tF %1$tT" format (new Date(context.started))
-    val elapse = "%,dms" format (context.stopped.get - context.started)
-    val thread = "[" + context.thread.getName + "]"
-    val thisObject = if (context.thisObject == null) "null" else context.thisObject.toString
-    val method = context.className + "." + context.methodName
-    val arguments = context.arguments.mkString("[", " ", "]")
-    val resultOrExcption = context.resultOrException match {
-      case Some(x)                      => JsonWriter.objectToJson(x)
-      case None if context.isVoidReturn => "void"
-      case None                         => "null"
-    }
-    val line = (started :: elapse :: thread :: thisObject :: method :: arguments :: resultOrExcption :: Nil)
-      .mkString(" ")
-    writer.write(line)
-    writer.newLine()
-
-    context.resultOrException match {
-      case Some(x) if x.isInstanceOf[Throwable] => x.asInstanceOf[Throwable].getStackTrace.foreach {
-        s =>
-          writer.write("\tat " + s)
-          writer.newLine()
-      }
-      case _                                    =>
-    }
-  }
-
-  override def close() {
-    try {writer.close()} catch {case _ => }
-  }
-}
-
 class StackWriter(writer: BufferedWriter) {
   def write(context: Context) {
     // TODO Avoid duplicated stack

--- a/src/main/scala/com/github/zhongl/housemd/instrument/Context.scala
+++ b/src/main/scala/com/github/zhongl/housemd/instrument/Context.scala
@@ -16,6 +16,8 @@
 
 package com.github.zhongl.housemd.instrument
 
+import com.github.zhongl.housemd.misc.ObjUtils
+
 
 /**
  * @author <a href="mailto:zhong.lunfu@gmail.com">zhongl<a>
@@ -42,7 +44,7 @@ object Context {
     map.get(Advice.CLASS).asInstanceOf[String],
     map.get(Advice.METHOD).asInstanceOf[String],
     map.get(Advice.CLASS_LOADER).asInstanceOf[ClassLoader],
-    map.get(Advice.ARGUMENTS).asInstanceOf[Array[AnyRef]] map (Option(_).getOrElse("null").toString),
+    map.get(Advice.ARGUMENTS).asInstanceOf[Array[AnyRef]] map ObjUtils.toString,
     map.get(Advice.DESCRIPTOR).asInstanceOf[String],
     map.get(Advice.VOID_RETURN).asInstanceOf[Boolean],
     map.get(Advice.THIS),

--- a/src/main/scala/com/github/zhongl/housemd/misc/ObjUtils.scala
+++ b/src/main/scala/com/github/zhongl/housemd/misc/ObjUtils.scala
@@ -1,0 +1,25 @@
+package com.github.zhongl.housemd.misc
+
+import com.cedarsoftware.util.io.JsonWriter
+
+/**
+ * @author <a href="mailto:eagleinfly@gmail.com">eagleinfly<a>
+ */
+object ObjUtils {
+  val jsonFormater = (ref: AnyRef) => JsonWriter.objectToJson(ref)
+  val toStringFormater = (ref: AnyRef) => Option(ref).getOrElse("null").toString
+
+  var formatter = toStringFormater
+
+  def useJsonFormat() = {
+    formatter = jsonFormater
+  }
+
+  def useToStringFormat() = {
+    formatter = toStringFormater
+  }
+
+  def toString(obj: AnyRef) = {
+    formatter(obj)
+  }
+}

--- a/src/main/scala/com/github/zhongl/housemd/misc/ObjUtils.scala
+++ b/src/main/scala/com/github/zhongl/housemd/misc/ObjUtils.scala
@@ -7,16 +7,20 @@ import com.cedarsoftware.util.io.JsonWriter
  */
 object ObjUtils {
   val jsonFormater = (ref: AnyRef) => JsonWriter.objectToJson(ref)
+
   val toStringFormater = (ref: AnyRef) => Option(ref).getOrElse("null").toString
 
   var formatter = toStringFormater
+  var parameterSeparator: String = " "
 
   def useJsonFormat() = {
     formatter = jsonFormater
+    parameterSeparator = "\n"
   }
 
   def useToStringFormat() = {
     formatter = toStringFormater
+    parameterSeparator = " "
   }
 
   def toString(obj: AnyRef) = {

--- a/src/test/scala/com/github/zhongl/housemd/misc/ObjUtilsSpec.scala
+++ b/src/test/scala/com/github/zhongl/housemd/misc/ObjUtilsSpec.scala
@@ -1,0 +1,45 @@
+package com.github.zhongl.housemd.misc;
+
+import org.scalatest.FunSpec
+import org.scalatest.matchers.ShouldMatchers
+
+/**
+ * @author <a href="mailto:eagleinfly@gmail.com">eagleinfly<a>
+ */
+class ObjUtilsSpec extends FunSpec with ShouldMatchers {
+  describe("ObjUtils") {
+    it("should format object in json format") {
+      ObjUtils.useJsonFormat()
+      ObjUtils.toString(null) should be("null")
+      ObjUtils.toString("") should be("\"\"")
+      ObjUtils.toString("string") should be("\"string\"")
+    }
+
+    it("should format object in toString format") {
+      ObjUtils.useToStringFormat()
+      ObjUtils.toString(null) should be("null")
+      ObjUtils.toString("") should be("")
+      ObjUtils.toString("string") should be("string")
+    }
+
+    it("should format objects with cycle reference in json format") {
+      class A{
+        var b: B = null
+        var intVal: Int = 0
+        var intObj: java.lang.Integer = null
+        def setB(b: B) = this.b = b
+      }
+
+      class B{
+        var a: A = null
+        def setA(a: A) = this.a = a
+      }
+
+      val a = new A
+      a.b = new B
+      a.b.a = a
+      ObjUtils.useJsonFormat()
+      ObjUtils.toString(a) should not(be(null))
+    }
+  }
+}


### PR DESCRIPTION
I introduced json option for trace detail, and the example usage is:

trace -d -j Main.test
or
trace -d --json Main.test

The current trace detail are logged by using toString() method. In some situation, it can't describe everything we want to see. And it also required to change the source code when we want to change the output.

To make the detail output more useful, we need to print the FULL object, and json is a pretty good format for this purpose.

To make the output clear, I'm using '\n' to separate multiple arguments when using json format.

I chose "json-io" because it can handle circle reference by default. I also added a test for that.

There are several other changes: 
1. I could not run sbt compile until I upgrade sbt.version to 0.12.4
2. I disabled sbt-idea and sbteclipse-plugin because I could not find them

Please contact me if any problem. Thanks.
